### PR TITLE
Build and push operator, bundle and catalog images on main push

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -1,0 +1,70 @@
+---
+name: Build and push operator, bundle and catalog images
+
+on:
+  repository_dispatch:
+    types:
+      - operand-image-update
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+
+env:
+  IMAGE_NAME: ${{ github.repository }}
+  REGISTRY: ghcr.io
+
+jobs:
+  get-operator-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+    steps:
+      - name: Identify version based on branch
+        id: get-version
+        run: |
+          if [ ${{ github.ref_name }} == "main" ]; then
+              version="99.0.0"
+          else
+              version="${{ github.ref_name }}"
+          fi
+          echo "::set-output name=version::${version}"
+
+  build-images:
+    needs: get-operator-version
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.get-operator-version.outputs.version }}
+    steps:
+      - name: Checkout current repository for the Dockerfiles
+        uses: actions/checkout@v3
+
+      - name: Login to the container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ env.VERSION }}
+        id: build-push-operator
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ env.VERSION }}"
+
+      - name: Build and push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-bundle:v${{ env.VERSION }}
+        id: build-push-operator-bundle
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: bundle.Dockerfile
+          push: true
+          tags: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-bundle:v${{ env.VERSION }}"
+
+      - name: Build and push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:v${{ env.VERSION }}
+        run: make catalog-build && make catalog-push
+        env:
+          BUNDLE_IMG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-bundle@${{ steps.build-push-operator-bundle.outputs.digest }}


### PR DESCRIPTION
This PR adds a Github CI workflow to build and push the operator, the bundle and the catalog container images to [ghcr.io](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).

Signed-off-by: Michail Resvanis <mresvani@redhat.com>