### PR TITLE
Add CI and report badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+![lint](https://github.com/empovit/fdo-operator/actions/workflows/lint.yaml/badge.svg)
+![tests](https://github.com/empovit/fdo-operator/actions/workflows/test.yaml/badge.svg)
+[![codecov](https://codecov.io/gh/empovit/fdo-operator/branch/main/graph/badge.svg?token=EMH9QLP6NR)](https://codecov.io/gh/empovit/fdo-operator)
+[![go report](https://goreportcard.com/badge/github.com/empovit/fdo-operator)](https://goreportcard.com/report/github.com/empovit/fdo-operator)
+![Build and push images](https://github.com/empovit/fdo-operator/actions/workflows/images.yaml/badge.svg)
+
 # fdo-operator
 // TODO(user): Add simple overview of use/purpose
 


### PR DESCRIPTION
This change adds the following badges at the top of the repository's README:

- unit test workflow
- lint workflow
- [codecov](https://about.codecov.io/) test coverage
- [goreportcard](https://goreportcard.com/)
- build and push image worflow

Signed-off-by: Michail Resvanis <mresvani@redhat.com>

Draft until https://github.com/empovit/fdo-operator/pull/17 is merged.