### PR TITLE
Fix GitHub set-output deprecation warning

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -29,7 +29,7 @@ jobs:
           else
               version="${{ github.ref_name }}"
           fi
-          echo "::set-output name=version::${version}"
+          echo "version=${version}" >> $GITHUB_OUTPUT
 
   build-images:
     needs: get-operator-version


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/