### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4"

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,6 @@ jobs:
       run: make test
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         files: cover.out


### PR DESCRIPTION
Reverts empovit/fdo-operator#95

Due to codecov-action@v4 is being a beta version
```
Error: Unable to resolve action `codecov/codecov-action@v4`, unable to find version `v4`
```
